### PR TITLE
refactor:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv/
+.git/
+.idea/

--- a/.idea/chinese-address-generator.iml
+++ b/.idea/chinese-address-generator.iml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
     <orderEntry type="jdk" jdkName="Python 3.8 (base)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/chinese_address_generator/__init__.py
+++ b/chinese_address_generator/__init__.py
@@ -7,13 +7,15 @@
 import json
 import platform
 import os
-
-if platform.system() == 'Windows':
-    path1 = str(os.path.dirname(os.__file__) + '\\site-packages\\chinese_address_generator\\src\\level3.json')
-    path2 = os.path.dirname(os.__file__) + '\\site-packages\\chinese_address_generator\\src\\level4.txt'
-else:
-    path1 = os.path.dirname(os.__file__) + '/site-packages/chinese_address_generator/src/level3.json'
-    path2 = os.path.dirname(os.__file__) + '/site-packages/chinese_address_generator/src/level4.txt'
+from pathlib2 import Path
+path1 = Path(__file__).parent.joinpath("src").joinpath("level3.json")
+path2 = Path(__file__).parent.joinpath("src").joinpath("level4.txt")
+# if platform.system() == 'Windows':
+#     path1 = str(os.path.dirname(os.__file__) + '\\site-packages\\chinese_address_generator\\src\\level3.json')
+#     path2 = os.path.dirname(os.__file__) + '\\site-packages\\chinese_address_generator\\src\\level4.txt'
+# else:
+#     path1 = os.path.dirname(os.__file__) + '/site-packages/chinese_address_generator/src/level3.json'
+#     path2 = os.path.dirname(os.__file__) + '/site-packages/chinese_address_generator/src/level4.txt'
 
 level3_list = json.loads(open(path1, 'r', encoding='utf-8').read())
 level4_list = open(path2, 'r', encoding='utf-8').readlines()

--- a/chinese_address_generator/generator.py
+++ b/chinese_address_generator/generator.py
@@ -8,6 +8,7 @@ import json
 import random
 import os
 import platform
+from pathlib2 import Path
 
 
 # class Generator:
@@ -21,19 +22,21 @@ import platform
 
 # read json file to get level3 address
 def jsonreader():
-    if platform.system() == 'Windows':
-        path = os.path.dirname(os.__file__) + '\\site-packages\\chinese_address_generator\\src\\level3.json'
-    else:
-        path = os.path.dirname(os.__file__) + '/site-packages/chinese_address_generator/src/level3.json'
+    path = Path(__file__).parent.joinpath("src").joinpath("level3.json")
+    # if platform.system() == 'Windows':
+    #     path = os.path.dirname(os.__file__) + '\\site-packages\\chinese_address_generator\\src\\level3.json'
+    # else:
+    #     path = os.path.dirname(os.__file__) + '/site-packages/chinese_address_generator/src/level3.json'
     return json.loads(open(path, 'r', encoding='utf-8').read())
 
 
 # read txt file to get level4 address
 def txtreader():
-    if platform.system() == 'Windows':
-        path = os.path.dirname(os.__file__) + '\\site-packages\\chinese_address_generator\\src\\level4.txt'
-    else:
-        path = os.path.dirname(os.__file__) + '/site-packages/chinese_address_generator/src/level4.txt'
+    path = Path(__file__).parent.joinpath("src").joinpath("level4.txt")
+    # if platform.system() == 'Windows':
+    #     path = os.path.dirname(os.__file__) + '\\site-packages\\chinese_address_generator\\src\\level4.txt'
+    # else:
+    #     path = os.path.dirname(os.__file__) + '/site-packages/chinese_address_generator/src/level4.txt'
     return open(path, 'r', encoding='utf-8').readlines()
 
 


### PR DESCRIPTION
将数据读取路径由全局site-packages改为虚拟环境site-packages.
将路径操作全部使用pathlib2替换, 以提供跨平台支持